### PR TITLE
Align frontend with backend2 and add combined dev runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ yarn dev
 
 Your frontend will be running at: `http://localhost:3000`
 
+### 🔁 Run Frontend & Backend Together
+
+```bash
+# From project root
+npm run dev:full
+```
+
+This single command starts the FastAPI backend from `backend2/main-improved.py` on `http://localhost:8000` and the Vite development server simultaneously, keeping both services in sync during development.
+
 ### 4. Access the Application
 
 Open your browser and go to: `http://localhost:3000`

--- a/backend2/main-improved.py
+++ b/backend2/main-improved.py
@@ -1368,7 +1368,7 @@ if __name__ == "__main__":
     print("")
     
     uvicorn.run(
-        "main-improved:app",
+        app,
         host="0.0.0.0",
         port=8000,
         reload=True,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:backend": "python backend2/main-improved.py",
+    "dev:full": "node scripts/dev-full.js",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/scripts/dev-full.js
+++ b/scripts/dev-full.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+
+const processes = [];
+let exiting = false;
+
+function startProcess(name, command, args) {
+  const child = spawn(command, args, {
+    stdio: 'inherit',
+    shell: true,
+    env: {
+      ...process.env,
+      FORCE_COLOR: process.env.FORCE_COLOR ?? '1',
+    },
+  });
+
+  processes.push({ name, child });
+
+  child.on('exit', (code, signal) => {
+    if (exiting) {
+      return;
+    }
+
+    exiting = true;
+    if (signal) {
+      console.log(`\n${name} exited with signal ${signal}`);
+    } else if (code !== 0) {
+      console.error(`\n${name} exited with code ${code}`);
+    }
+
+    for (const proc of processes) {
+      if (proc.child.pid && !proc.child.killed) {
+        proc.child.kill('SIGTERM');
+      }
+    }
+
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+}
+
+function handleShutdown(signal) {
+  if (exiting) return;
+  exiting = true;
+
+  console.log(`\nReceived ${signal}. Shutting down...`);
+  for (const proc of processes) {
+    if (proc.child.pid && !proc.child.killed) {
+      proc.child.kill(signal);
+    }
+  }
+}
+
+process.on('SIGINT', () => handleShutdown('SIGINT'));
+process.on('SIGTERM', () => handleShutdown('SIGTERM'));
+
+startProcess('backend', 'npm', ['run', 'dev:backend']);
+startProcess('frontend', 'npm', ['run', 'dev']);

--- a/src/components/MistAI.tsx
+++ b/src/components/MistAI.tsx
@@ -9,7 +9,7 @@ import { Sidebar } from './Sidebar';
 import { ChatMessage } from './ChatMessage';
 import { Menu, Sparkles, BookOpen, Users, GraduationCap } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { api } from '@/lib/api';
+import { api, API_BASE_URL } from '@/lib/api';
 
 interface UserProfile {
   name: string;
@@ -90,7 +90,7 @@ export const MistAI: React.FC = () => {
   const generateResponse = useCallback(async (query: string): Promise<string> => {
     try {
       console.log('Calling backend API for query:', query);
-      console.log('API URL:', 'http://localhost:8000/api/chat');
+      console.log('API URL:', `${API_BASE_URL}/api/chat`);
       
       // Create a consistent user ID - use 'user_shadow' to match existing backend data
       const user_id = 'user_shadow'; // Fixed user ID to match backend

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,8 @@
 // API Configuration for SRM Guide Bot
-const API_BASE_URL = 'http://localhost:8000';
+const DEFAULT_API_BASE_URL = 'http://localhost:8000';
+
+export const API_BASE_URL =
+  import.meta.env?.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL;
 
 export const api = {
   // Health check

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- expose a configurable API base URL for the frontend and reuse it in the MistAI component
- add scripts to start the FastAPI backend and a helper to run frontend and backend together, documenting the workflow
- fix the improved backend entrypoint to launch uvicorn using the in-memory app instance

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_69098c1a1b6c8333bba300916afb5896